### PR TITLE
Add ssh-auth-sock to docs example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,7 @@ jobs:
       - uses: webfactory/ssh-agent@v0.1.1
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ssh-auth-sock: ${{ github.workspace }}/ssh-auth.sock
 
       - uses: steenbergen-design/trellis-action@v1
         with: 


### PR DESCRIPTION
First, thanks for a great action! It saved my day and move from Bitbucket to Github 🏆

But I found out that to make this action to work properly I had to set `ssh-auth-sock: ${{ github.workspace }}/ssh-auth.sock` in the ssh action config.

I'm not 100% sure why it's needed but thought it might be good to mention it in the documentation more properly. Maybe you know more why it's needed? 

Also, feel free to skip it if you think this has more to do with my setup than with the actual project!