### PR TITLE
Bump ansible version to 2.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
   
-FROM cytopia/ansible:2.7-tools
+FROM cytopia/ansible:2.8-tools
 
 COPY ./dist/index.js /index.js
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "steenbergendesign-action-trellis",
     "repository": "",
     "description": "GitHub Action to deploy to trellis environmnet",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "main": "index.js",
     "author": "Steenbergen Design <arjan@steenbergen.design>",
     "license": "MIT",


### PR DESCRIPTION
## Overview

ref: https://discourse.roots.io/t/provisioning-server-not-working-because-ansible-ssh-extra-args-is-undefined/17484

```
TASK [connection : Specify preferred HostKeyAlgorithms for unknown hosts] ******
  System info:
    Ansible 2.7.16; Linux
    Trellis version (per changelog): "Removes ID from Lets Encrypt bundled certificate and make filename stable"
  ---------------------------------------------------
  The conditional check 'not (not ansible_ssh_extra_args)' failed. The error
  was: error while evaluating conditional (not (not ansible_ssh_extra_args)):
  'ansible_ssh_extra_args' is undefined
  
  The error appears to have been in
  '/github/workspace/trellis/roles/connection/tasks/main.yml': line 9, column
  3, but may
  be elsewhere in the file depending on the exact syntax problem.
  
  The offending line appears to be:
  
  
  - name: Specify preferred HostKeyAlgorithms for unknown hosts
    ^ here
 
  
   [WARNING]: Skipping plugin
  (/github/workspace/trellis/lib/trellis/plugins/callback/vars.py) as it seems to
  be invalid: cannot import name 'context'
  
   [WARNING]: Skipping plugin
  (/github/workspace/trellis/lib/trellis/plugins/vars/version.py) as it seems to be invalid: Trellis no longer supports Ansible 2.7.16. Please upgrade to
  Ansible 2.8.0 or higher.

```

## What has been done?

Bump `cytopia/ansible` docker image to version **2.8**

